### PR TITLE
Using available space better

### DIFF
--- a/src/resources/css/codemirror.css
+++ b/src/resources/css/codemirror.css
@@ -3,7 +3,8 @@
 .CodeMirror {
   /* Set height, width, borders, and global font properties here */
   font-family: monospace;
-  height: 300px;
+  height: calc(100vh - 210px);
+  min-height: 300px;
 }
 
 /* PADDING */


### PR DESCRIPTION
Having the code editor at only 300px is a bit small. There is a bunch of space below it, this change makes it fit the window perfectly (with the title still visible). This would also be usefull in the cpcss plugin