### PR TITLE
Added multipath enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ After you've installed the plugin, go to:
 
 Your custom JavaScript can be saved in either (or both) of two places:
 
-**1) An external file in your public directory...**
+**1) One or more external files in your public directory delimited by commas...**
 ![](src/resources/img/example-jsFile.png)
 
 **2) The "Additional JavaScript" field on the settings page...**

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -11,8 +11,8 @@
 <p>Your custom JavaScript will be applied to the entire Control Panel.</p>
 
 {{ forms.autosuggestField({
-    label: "JavaScript File"|t,
-    instructions: "Enter the path to your JavaScript file."|t,
+    label: "JavaScript File(s)"|t,
+    instructions: "Enter the path to your JavaScript file(s). Multiple filepaths may be delimited by commas."|t,
     id: 'jsFile',
     name: 'jsFile',
     suggestEnvVars: true,

--- a/src/web/assets/CustomAssets.php
+++ b/src/web/assets/CustomAssets.php
@@ -36,15 +36,25 @@ class CustomAssets extends AssetBundle
 
         $file = trim(Craft::parseEnv($settings['jsFile']));
 
+        $finalPaths = [];
+
         if ($file) {
 
-            // Cache buster
-            if ($hash = @sha1_file($file)) {
-                $file .= '?e='.$hash;
+            $files = explode(',', $file);
+            foreach ($files as $file) {
+                $file = trim($file);
+
+                // Cache buster
+                if ($hash = @sha1_file($file)) {
+                    $file .= '?e='.$hash;
+                }
+
+                array_push($finalPaths, $file);
+
             }
 
-            // Load JS file
-            $this->js = [$file];
+            // Load all cachebusted JS files
+            $this->js = $finalPaths;
 
         }
     }


### PR DESCRIPTION
I came across a situation that needed my control panel javascript to be separate files so I could perform io on one of them via a script more cleanly.  I feel like this might be helpful to others in organizing multiple large additions to the control panel.

Multiple JS filepaths can now be added by delimiting
the paths with a comma

Example
cdn-website/path, /jscp2.js

P.S.  That sha1 cachebuster bit is brilliant!