### PR TITLE
Listen for EVENT_BEFORE_RENDER_PAGE_TEMPLATE event

### DIFF
--- a/src/CpJs.php
+++ b/src/CpJs.php
@@ -50,10 +50,10 @@ class CpJs extends Plugin
             return false;
         }
 
-        // Load JS before template is rendered
+        // Load JS before page template is rendered
         Event::on(
             View::class,
-            View::EVENT_BEFORE_RENDER_TEMPLATE,
+            View::EVENT_BEFORE_RENDER_PAGE_TEMPLATE,
             function (TemplateEvent $event) {
 
                 // Get view


### PR DESCRIPTION
Listening for the `EVENT_BEFORE_RENDER_TEMPLATE` event means that the JS code is executed each time any template is rendered, including when matrix blocks are created. Changing the event to `EVENT_BEFORE_RENDER_PAGE_TEMPLATE` ensures that the code only executes when a page is rendered.